### PR TITLE
move chunklist declaration inside emit plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ function ChunkListWebpackPlugin(options) {
 
 ChunkListWebpackPlugin.prototype.apply = function(compiler) {
   var OPTS = this.opts;
-  var chunksList = [];
 
   compiler.plugin('emit', function(compilation, callback) {
+    var chunksList = [];
+    
     compilation.chunks.forEach(function(chunk) {
       chunk.files.forEach(function(filename) {
         var ext = getFileExtension(filename);


### PR DESCRIPTION
Move `chunkList` declaration inside the `emit` callback.  
Makes sure a new array is declared after each compilation instead of reusing the same one, since using this together with watch mode produced a very big `chunk-list.json` file 😅 

Resolves #1 